### PR TITLE
updated metalink/metafile with internal ComplexOutput

### DIFF
--- a/pywps/templates/metalink/3.0/main.xml
+++ b/pywps/templates/metalink/3.0/main.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metalink version="3.0" xmlns="http://www.metalinker.org/">
-    {% if identity %}
-    <identity>{{ identity }}</identity>
+    {% if meta.identity %}
+    <identity>{{ meta.identity }}</identity>
     {% endif %}
-    {% if description %}
-    <description>{{ description }}</description>
+    {% if meta.description %}
+    <description>{{ meta.description }}</description>
     {% endif %}
-    {% if publisher %}
-    <publisher>{{ publisher }}</publisher>
+    {% if meta.publisher %}
+    <publisher>{{ meta.publisher }}</publisher>
     {% endif %}
     <files>
-        {% for file in files %}
+        {% for file in meta.files %}
         <file name="{{ file.name }}">
             {% if file.identity %}
             <identity>{{ file.identity }}</identity>

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -694,23 +694,18 @@ class BoxOutputTest(unittest.TestCase):
 class TestMetaLink(unittest.TestCase):
     tmp_dir = tempfile.mkdtemp()
 
-    def co(self):
-        out = inout.outputs.ComplexOutput('identifier', 'title', abstract='abstract test ',
-                                          supported_formats=[FORMATS.JSON, ],
-                                          as_reference=True,)
-        out.data = json.dumps({'a': 1})
-        out.workdir = self.tmp_dir
-        return out
-
     def metafile(self):
-        return MetaFile(self.co())
+        mf = MetaFile('identifier', 'title', format=FORMATS.JSON)
+        mf.data = json.dumps({'a': 1})
+        mf._set_workdir(self.tmp_dir)
+        return mf
 
     def test_metafile(self):
         mf = self.metafile()
-        self.assertEqual('identifier', mf.attrs['identity'])
+        self.assertEqual('identifier', mf.identity)
 
     def metalink(self):
-        ml = MetaLink(identity='unittest', description='desc', files=(self.metafile(), ))
+        ml = MetaLink(identity='unittest', description='desc', files=(self.metafile(), ), workdir=self.tmp_dir)
         return ml
 
     def test_metalink(self):


### PR DESCRIPTION
# Overview

This PR is an update of the `MetaLink` and `MetaFile` class. The main change is to use a `ComplexOutput` internally in `MetaFile`.

# Related Issue / Discussion

#298.

# Additional Information

See an example in Emu with MetaLink usage:
https://github.com/bird-house/emu/blob/dev-mutliple-outputs/emu/processes/wps_multiple_outputs.py

# Contribution Agreement

(as per https://github.com/geopython/pywps/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x ] I'd like to contribute [feature X|bugfix Y|docs|something else] to PyWPS. I confirm that my contributions to PyWPS will be compatible with the PyWPS license guidelines at the time of contribution.
- [ ] I have already previously agreed to the PyWPS Contributions and Licensing Guidelines
